### PR TITLE
Fix CS0115 on Unity 6000.4+: compile out removed Compatibility Mode passes

### DIFF
--- a/Runtime/PhysicallyBasedSkyURP.cs
+++ b/Runtime/PhysicallyBasedSkyURP.cs
@@ -585,6 +585,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
         }
 
         #region Non Render Graph Pass
+    #if !UNITY_6000_4_OR_NEWER
         // Passing the final sun color to the Execute() method
         private float3 mainLightColor;
 
@@ -656,6 +657,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
             
             CommandBufferPool.Release(cmd);
         }
+    #endif
         #endregion
 
     #if UNITY_6000_0_OR_NEWER
@@ -1097,6 +1099,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
         }
 
         #region Non Render Graph Pass
+    #if !UNITY_6000_4_OR_NEWER
         bool lutDataChanged;
     #if UNITY_6000_0_OR_NEWER
         [Obsolete]
@@ -1274,6 +1277,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
             
             CommandBufferPool.Release(cmd);
         }
+    #endif
         #endregion
 
     #if UNITY_6000_0_OR_NEWER
@@ -1621,6 +1625,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
         }
 
         #region Non Render Graph Pass
+    #if !UNITY_6000_4_OR_NEWER
     #if UNITY_6000_0_OR_NEWER
         [Obsolete]
     #endif
@@ -1660,6 +1665,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
 
             CommandBufferPool.Release(cmd);
         }
+    #endif
         #endregion
 
     #if UNITY_6000_0_OR_NEWER
@@ -1826,6 +1832,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
         }
 
         #region Non Render Graph Pass
+    #if !UNITY_6000_4_OR_NEWER
     #if UNITY_6000_0_OR_NEWER
         [Obsolete]
     #endif
@@ -1854,6 +1861,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
             
             CommandBufferPool.Release(cmd);
         }
+    #endif
         #endregion
 
     #if UNITY_6000_0_OR_NEWER
@@ -1964,6 +1972,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
         }
 
         #region Non Render Graph Pass
+    #if !UNITY_6000_4_OR_NEWER
     #if UNITY_6000_0_OR_NEWER
         [Obsolete]
     #endif
@@ -2106,6 +2115,7 @@ public class PhysicallyBasedSkyURP : ScriptableRendererFeature
             
             CommandBufferPool.Release(cmd);
         }
+    #endif
         #endregion
 
     #if UNITY_6000_0_OR_NEWER


### PR DESCRIPTION
Unity **6000.4** removed URP's Render Graph Compatibility Mode, which deleted the base-class `ScriptableRenderPass.OnCameraSetup(CommandBuffer, ref RenderingData)` and `Execute(ScriptableRenderContext, ref RenderingData)` methods. The `#region Non Render Graph Pass` overrides therefore no longer compile:

```
error CS0115: '...PBSkyPrePass.Execute(ScriptableRenderContext, ref RenderingData)': no suitable method found to override
```

…ten of these, across `PBSkyPrePass`, `SkyViewLUTPass`, `AtmosphericScatteringPass`, `PBSkyPostPass`, and `AmbientProbePass`.

This guards each `#region Non Render Graph Pass` behind `#if !UNITY_6000_4_OR_NEWER`, so the Compatibility-Mode passes only compile on Unity 6.3 / older URP that still expose those APIs. Each region is self-contained (its only region-local fields, `mainLightColor` / `lutDataChanged`, are used solely within it), and the RenderGraph path (`RecordRenderGraph`) does its own handle allocation and keyword setup — so Unity 6 rendering is unchanged.

Restores compilation on Unity 6000.4 and 6000.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
